### PR TITLE
load services before controllers (fix nil ref)

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,19 +4,18 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 ui_page 'html/hud.html'
 
 client_scripts {
-    'client/controllers/*.lua',
-    'client/services/*.lua'
+    'client/services/*.lua',
+	'client/controllers/*.lua'    
 }
 
 server_scripts {
-    'server/controllers/*.lua',
-    'server/handlers/*.lua',
-    'server/services/*.lua'
+    'server/services/*.lua',
+	'server/controllers/*.lua',
+    'server/handlers/*.lua'
 }
 
 files {
     'ui/**/*',
-
 }
 
 


### PR DESCRIPTION
The controllers require services functions to exist, therefore services should load before controllers.
Otherwise, at least on my end, the controllers files were reporting nil references when assigning handlers.